### PR TITLE
Fix: Correct socket error check in server initialization

### DIFF
--- a/thecwebserver-code/cwebserver.c
+++ b/thecwebserver-code/cwebserver.c
@@ -23,7 +23,7 @@ int main (){
 
 
     // Create socket
-    if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
+    if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
         perror("Socket failed");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Changed the socket creation error check to `server_fd < 0` from `server_fd == 0` to properly handle failure cases.

From the `man` page of `socket`,

```txt
RETURN VALUES
     A -1 is returned if an error occurs, otherwise the return value is a descriptor referencing the socket.
```

Shout out to [Rezoan Ahmed Abir](https://github.com/rez-OAN/) for actually figuring this out. 