### PR TITLE
Fix: Fixing create_tables.sql only drop existent tables if they exist

### DIFF
--- a/e0/pg/create_tables.sql
+++ b/e0/pg/create_tables.sql
@@ -1,6 +1,6 @@
 
-DROP TABLE products;
-DROP TABLE product_types;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS product_types;
 CREATE TABLE products (
    pid SERIAL PRIMARY KEY,
    product_name TEXT,

--- a/e1/pg/create_tables.sql
+++ b/e1/pg/create_tables.sql
@@ -1,6 +1,6 @@
 
-DROP TABLE products;
-DROP TABLE product_types;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS product_types;
 CREATE TABLE products (
    pid SERIAL PRIMARY KEY,
    product_name TEXT,

--- a/e2/pg/create_tables.sql
+++ b/e2/pg/create_tables.sql
@@ -1,6 +1,6 @@
 
-DROP TABLE products;
-DROP TABLE product_types;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS product_types;
 CREATE TABLE products (
    pid SERIAL PRIMARY KEY,
    product_name TEXT,

--- a/e3/pg/create_tables.sql
+++ b/e3/pg/create_tables.sql
@@ -1,6 +1,6 @@
 
-DROP TABLE products;
-DROP TABLE product_types;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS product_types;
 CREATE TABLE products (
    pid SERIAL PRIMARY KEY,
    product_name TEXT,

--- a/e4/pg/create_tables.sql
+++ b/e4/pg/create_tables.sql
@@ -1,6 +1,6 @@
 
-DROP TABLE products;
-DROP TABLE product_types;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS product_types;
 CREATE TABLE products (
    pid SERIAL,
    product_name TEXT,


### PR DESCRIPTION
Changed the create_tables.sql to only drop the tables if they exist otherwise. Failing with docker approach (because they didn't existed before)